### PR TITLE
mutation-runner: Add --write-modules-to option to dump mutants to disk

### DIFF
--- a/mutate/trace.rkt
+++ b/mutate/trace.rkt
@@ -1,23 +1,37 @@
 #lang racket
 
-(provide trace-module)
+(provide trace-module
+         maybe-path->string make-safe-for-reading)
 
 
 (require syntax/parse
          syntax/strip-context
          "sandbox-runner.rkt")
 
+(define (maybe-path->string mp)
+  (if (path? mp) (path->string mp) mp))
+(define make-safe-for-reading
+  (match-lambda
+    [(? path? p)
+     (path->string p)]
+    [(? hash? h)
+     (for/hash ([(k v) (in-hash h)])
+       (values (make-safe-for-reading k)
+               (make-safe-for-reading v)))]
+    [(and other (or (? symbol?) (? string?)))
+     other]))
+
 ;; Produce the instrumented syntax for a module to run with flow-trace
 (define/contract (trace-module module-file-path module-stx precision-config)
-  (path-string?
+  (path?
    syntax?
-   (hash/c path-string?
-           (hash/c (or/c symbol? path-string?)
+   (hash/c path?
+           (hash/c (or/c symbol? path?)
                    symbol?))
    . -> .
    syntax?)
 
-  (define mod-path/simplified (path->string (simplify-path module-file-path)))
+  (define mod-path/simplified module-file-path)
   (define config-for-this-module
     (hash-ref precision-config mod-path/simplified
               (λ _
@@ -28,7 +42,7 @@
   (syntax-parse module-stx
     #:datum-literals [module]
     [(module name lang {~and mod-body (mod-begin body ...)})
-     #:with config-stx config-for-this-module
+     #:with config-stx (make-safe-for-reading config-for-this-module)
      #:with traced-mod-body
      (datum->syntax #'mod-body
                     (syntax-e #'(mod-begin
@@ -48,12 +62,12 @@
      (define-test (test-stx=? a b)
        (test-equal? (syntax->datum a)
                     (syntax->datum b)))
-     (define dummy-mod-path "/tmp/test.rkt")
+     (define dummy-mod-path (string->path "/tmp/test.rkt"))
      (define dummy-mod-stx #'(module mod-name racket (#%module-begin a b c))))
     (test-stx=? (trace-module dummy-mod-path
                               dummy-mod-stx
-                              (hash "/tmp/test.rkt" (hash 'a 'none 'b 'max)
-                                    "some-other-mod.rkt" (hash 'foo 'types)))
+                              (hash (string->path "/tmp/test.rkt") (hash 'a 'none 'b 'max)
+                                    (string->path "some-other-mod.rkt") (hash 'foo 'types)))
                 #'(module mod-name (submod flow-trace/collapsing compressed)
                     (#%module-begin
                      #:precision-config #hash((a . none) (b . max))

--- a/utilities/test-env.rkt
+++ b/utilities/test-env.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
-(provide define-test-env
-         resolve-path-string)
+(provide define-test-env)
 
 (require syntax/parse/define
          racket/file
@@ -30,6 +29,3 @@
         (when (directory-exists? d)
           (delete-directory/files d))))
     maybe-provides))
-
-(define (resolve-path-string path-str)
-  (path->string (path->complete-path (string->path path-str))))


### PR DESCRIPTION
Also, use paths everywhere instead of strings, to keep things more consistent. Since paths aren’t `read`/`write`-able, this means using `racket/serialize` a lot more.